### PR TITLE
Update A321_by_Glidi.sacfg

### DIFF
--- a/aircraftConfigs/A321_by_Glidi.sacfg
+++ b/aircraftConfigs/A321_by_Glidi.sacfg
@@ -26,7 +26,7 @@
         {
             "name": "IMC",
             "height": 1000,
-            "primaryCondition": "$sim/weather/visibility_reported_m < 5000 or\n((($sim/weather/cloud_base_msl_m[0] - $analysis.touchdown_combined.elevation) < 450)\nand $sim/weather/cloud_coverage[0] >= 4)",
+            "primaryCondition": "$sim/weather/visibility_reported_m < 5000 or ((($sim/weather/cloud_base_msl_m[0] - $analysis.touchdown_combined.elevation) < 450) and $sim/weather/cloud_coverage[0] >= 4)",
             "description": "Instrument approach in IMC conditions"
         },
         {
@@ -39,7 +39,7 @@
             "name": "VISUAL",
             "height": 500,
             "primaryCondition": "0",
-            "description": "Visual approach can only be selected manually\n\nPlugins -> StableApproach -> Check height"
+            "description": "Visual approach can only be selected manually Plugins -> StableApproach -> Check height"
         }
     ],
     "requirementGroups": [
@@ -52,7 +52,7 @@
                     "primaryCondition": "$analysis.rollout.rwy_remaining > 0",
                     "beginConditionMarker": "#TD_FIRST",
                     "endConditionMarker": "$clamb/stableapproach/position/groundspeed_kn < 60",
-                    "description": "Taxi speed when reaching end of runway\n"
+                    "description": "Taxi speed when reaching end of runway"
                 }
             ]
         },
@@ -61,7 +61,7 @@
                 {
                     "name": "Touchdown zone",
                     "type": 2,
-                    "primaryCondition": "$analysis.touchdown_combined.threshold_dist.max < $analysis.rwy.length.tdz and\n$analysis.touchdown_combined.threshold_dist.min > 0",
+                    "primaryCondition": "$analysis.touchdown_combined.threshold_dist.max < $analysis.rwy.length.tdz and $analysis.touchdown_combined.threshold_dist.min > 0",
                     "beginConditionMarker": "#CH",
                     "endConditionMarker": "#INSTANT",
                     "description": "Touchdown(s) within touchdown zone"
@@ -103,7 +103,7 @@
                     "primaryCondition": "$analysis.touchdown_combined.fpm_agl.max > -900",
                     "beginConditionMarker": "#CH",
                     "endConditionMarker": "#TAXI",
-                    "description": "Maximum sinkrate during touchdown:\n600 fpm"
+                    "description": "Maximum sinkrate during touchdown: 600 fpm"
                 },
                 {
                     "name": "Hard landing (fpm)",
@@ -111,7 +111,7 @@
                     "primaryCondition": "$analysis.touchdown_combined.fpm_agl.max > -600",
                     "beginConditionMarker": "#CH",
                     "endConditionMarker": "#TAXI",
-                    "description": "Maximum sinkrate during touchdown:\n600 fpm"
+                    "description": "Maximum sinkrate during touchdown: 600 fpm"
                 }
             ]
         },
@@ -124,7 +124,7 @@
                     "primaryCondition": "$analysis.touchdown_combined.g_vertical.max < 2.6",
                     "beginConditionMarker": "#CH",
                     "endConditionMarker": "#TAXI",
-                    "description": "Max vertical acceleration after touchdown:\n2.1 G"
+                    "description": "Max vertical acceleration after touchdown: 2.1 G"
                 },
                 {
                     "name": "Hard landing (g)",
@@ -132,7 +132,7 @@
                     "primaryCondition": "$analysis.touchdown_combined.g_vertical.max < 2.1",
                     "beginConditionMarker": "#CH",
                     "endConditionMarker": "#TAXI",
-                    "description": "Max vertical acceleration after touchdown:\n2.1 G"
+                    "description": "Max vertical acceleration after touchdown: 2.1 G"
                 }
             ]
         },
@@ -142,20 +142,20 @@
                 {
                     "name": "High sinkrate",
                     "type": 2,
-                    "primaryCondition": "if ($clamb/stableapproach/live/app/gs/type != 6)\n$sim/flightmodel/position/vh_ind_fpm > -1300;\nelse\n$sim/flightmodel/position/vh_ind_fpm >\n$clamb/stableapproach/live/app/gs/angle / 3 * -1300",
+                    "primaryCondition": "if ($clamb/stableapproach/live/app/gs/type != 6) $sim/flightmodel/position/vh_ind_fpm > -1300; else $sim/flightmodel/position/vh_ind_fpm > $clamb/stableapproach/live/app/gs/angle / 3 * -1300",
                     "beginConditionMarker": "#CH",
                     "endConditionMarker": "#TD_LAST",
                     "tolerance": 3000,
-                    "description": "Max sinkrate during approach is normally:\n1000fpm"
+                    "description": "Max sinkrate during approach is normally: 1000fpm"
                 },
                 {
                     "name": "High sinkrate",
                     "type": 1,
-                    "primaryCondition": "if ($clamb/stableapproach/live/app/gs/type != 6)\n$sim/flightmodel/position/vh_ind_fpm > -1100;\nelse\n$sim/flightmodel/position/vh_ind_fpm >\n$clamb/stableapproach/live/app/gs/angle / 3 * -1100",
+                    "primaryCondition": "if ($clamb/stableapproach/live/app/gs/type != 6) $sim/flightmodel/position/vh_ind_fpm > -1100; else $sim/flightmodel/position/vh_ind_fpm > $clamb/stableapproach/live/app/gs/angle / 3 * -1100",
                     "beginConditionMarker": "#CH",
                     "endConditionMarker": "#TAXI",
                     "tolerance": 3000,
-                    "description": "Max sinkrate during approach is normally:\n1000fpm"
+                    "description": "Max sinkrate during approach is normally: 1000fpm"
                 }
             ]
         },
@@ -165,20 +165,20 @@
                 {
                     "name": "Approach speed",
                     "type": 2,
-                    "primaryCondition": "($toliss_airbus/pfdoutputs/general/VLS_value - 3) <= $sim/cockpit2/gauges/indicators/airspeed_kts_pilot\nand\n($toliss_airbus/pfdoutputs/general/VLS_value + 20) >= $sim/cockpit2/gauges/indicators/airspeed_kts_pilot",
+                    "primaryCondition": "($toliss_airbus/pfdoutputs/general/VLS_value - 3) <= $sim/cockpit2/gauges/indicators/airspeed_kts_pilot and ($toliss_airbus/pfdoutputs/general/VLS_value + 20) >= $sim/cockpit2/gauges/indicators/airspeed_kts_pilot",
                     "beginConditionMarker": "#CH",
                     "endConditionMarker": "$.ft_ARTE < 100",
                     "tolerance": 3000,
-                    "description": "Speed during approach must be between:\nVLS and VLS + 15"
+                    "description": "Speed during approach must be between: VLS and VLS + 15"
                 },
                 {
                     "name": "Approach speed",
                     "type": 1,
-                    "primaryCondition": "($toliss_airbus/pfdoutputs/general/VLS_value) <= $sim/cockpit2/gauges/indicators/airspeed_kts_pilot\nand\n($toliss_airbus/pfdoutputs/general/VLS_value + 15) >= $sim/cockpit2/gauges/indicators/airspeed_kts_pilot",
+                    "primaryCondition": "($toliss_airbus/pfdoutputs/general/VLS_value) <= $sim/cockpit2/gauges/indicators/airspeed_kts_pilot and ($toliss_airbus/pfdoutputs/general/VLS_value + 15) >= $sim/cockpit2/gauges/indicators/airspeed_kts_pilot",
                     "beginConditionMarker": "#CH",
                     "endConditionMarker": "$.ft_ARTE < 100",
                     "tolerance": 3000,
-                    "description": "Speed during approach must be between:\nVLS and VLS + 15"
+                    "description": "Speed during approach must be between: VLS and VLS + 15"
                 }
             ]
         },
@@ -191,10 +191,10 @@
                     "primaryCondition": "abs($AirbusFBW/ILS1GSRaw) < 1.3",
                     "beginConditionMarker": "#CH",
                     "endConditionMarker": "$.ft_ARTE < 200",
-                    "secondaryCondition": "$analysis.app.nav.gs.type == 6 and\n$.not_vis_app",
+                    "secondaryCondition": "$analysis.app.nav.gs.type == 6 and $.not_vis_app",
                     "secondaryConditionMarker": "#TD-3000ms",
                     "tolerance": 2000,
-                    "description": "Maximum 1 dot glideslope deviation.\nFrom check height until 200ft above runway threshold elevation (ARTE).\nNot required for VISUAL approaches"
+                    "description": "Maximum 1 dot glideslope deviation. From check height until 200ft above runway threshold elevation (ARTE). Not required for VISUAL approaches"
                 },
                 {
                     "name": "Glideslope deviation",
@@ -202,9 +202,9 @@
                     "primaryCondition": "abs($AirbusFBW/ILS1GSRaw) < 1",
                     "beginConditionMarker": "#CH",
                     "endConditionMarker": "$.ft_ARTE < 200",
-                    "secondaryCondition": "$analysis.app.nav.gs.type == 6 and\n$.not_vis_app",
+                    "secondaryCondition": "$analysis.app.nav.gs.type == 6 and $.not_vis_app",
                     "secondaryConditionMarker": "#TD-3000ms",
-                    "description": "Maximum 1 dot glideslope deviation.\nFrom check height until 200ft above runway threshold elevation (ARTE).\nNot required for VISUAL approaches"
+                    "description": "Maximum 1 dot glideslope deviation. From check height until 200ft above runway threshold elevation (ARTE). Not required for VISUAL approaches"
                 }
             ]
         },
@@ -217,10 +217,10 @@
                     "primaryCondition": "abs($AirbusFBW/ILS1LocRaw) < 1.3",
                     "beginConditionMarker": "#CH",
                     "endConditionMarker": "#TD-3000ms",
-                    "secondaryCondition": "$analysis.app.nav.loc.type != 0 and\n$.not_vis_app",
+                    "secondaryCondition": "$analysis.app.nav.loc.type != 0 and $.not_vis_app",
                     "secondaryConditionMarker": "#TD-3000ms",
                     "tolerance": 2000,
-                    "description": "Maximum 1 dot localizer deviation\nfrom check height till touchdown.\nNot required for VISUAL approaches"
+                    "description": "Maximum 1 dot localizer deviation from check height till touchdown. Not required for VISUAL approaches"
                 },
                 {
                     "name": "Localizer deviation",
@@ -228,10 +228,10 @@
                     "primaryCondition": "abs($AirbusFBW/ILS1LocRaw) < 1",
                     "beginConditionMarker": "#CH",
                     "endConditionMarker": "#TD-3000ms",
-                    "secondaryCondition": "$analysis.app.nav.loc.type != 0 and\n$.not_vis_app",
+                    "secondaryCondition": "$analysis.app.nav.loc.type != 0 and $.not_vis_app",
                     "secondaryConditionMarker": "#TD-3000ms",
                     "tolerance": 2000,
-                    "description": "Maximum 1 dot localizer deviation\nfrom check height till touchdown.\nNot required for VISUAL approaches"
+                    "description": "Maximum 1 dot localizer deviation from check height till touchdown. Not required for VISUAL approaches"
                 }
             ]
         },
@@ -241,10 +241,10 @@
                 {
                     "name": "Gear not down",
                     "type": 2,
-                    "primaryCondition": "$AirbusFBW/RightGearInd == 2 and\n$AirbusFBW/LeftGearInd == 2 and\n$AirbusFBW/NoseGearInd == 2\n",
+                    "primaryCondition": "$AirbusFBW/RightGearInd == 2 and $AirbusFBW/LeftGearInd == 2 and $AirbusFBW/NoseGearInd == 2",
                     "beginConditionMarker": "#CH",
                     "endConditionMarker": "#TAXI",
-                    "description": "Gear must be down and locked\nbelow check height"
+                    "description": "Gear must be down and locked below check height"
                 }
             ]
         },
@@ -254,7 +254,7 @@
                 {
                     "name": "Flaps not in position",
                     "type": 2,
-                    "primaryCondition": "$sim/cockpit2/controls/flap_handle_deploy_ratio == 1 or\n$sim/cockpit2/controls/flap_handle_deploy_ratio == 0.75",
+                    "primaryCondition": "$sim/cockpit2/controls/flap_handle_deploy_ratio == 1 or $sim/cockpit2/controls/flap_handle_deploy_ratio >= 0.745",
                     "beginConditionMarker": "#CH",
                     "endConditionMarker": "$sim/cockpit2/gauges/indicators/airspeed_kts_pilot < 60",
                     "description": "Flaps must be in landing position (3/FULL) below check height until taxi speed"
@@ -273,7 +273,7 @@
                     "secondaryCondition": "$analysis.rollout.go_around == 0",
                     "secondaryConditionMarker": "#TD-3000ms",
                     "tolerance": 500,
-                    "description": "Speedbrakes must be in the ARMED position\nbelow check height.\nNot required in case of touch-and-go"
+                    "description": "Speedbrakes must be in the ARMED position below check height. Not required in case of touch-and-go"
                 }
             ]
         },
@@ -304,18 +304,18 @@
                 {
                     "name": "Tailstrike",
                     "type": 2,
-                    "primaryCondition": "$analysis.touchdown_combined.pitch.max < 10.8\nand\n$analysis.rollout.pitch.max < 10.8",
+                    "primaryCondition": "$analysis.touchdown_combined.pitch.max < 10.8 and $analysis.rollout.pitch.max < 10.8",
                     "beginConditionMarker": "#CH",
                     "endConditionMarker": "#INSTANT",
-                    "description": "Very high pitch attitude!\nTailstrike most likely occured.\nMake sure your speed at touchdown is not (much) below VLS"
+                    "description": "Very high pitch attitude! Tailstrike most likely occured. Make sure your speed at touchdown is not (much) below VLS"
                 },
                 {
                     "name": "Touchdown high pitch attitude",
                     "type": 1,
-                    "primaryCondition": "$analysis.touchdown_combined.pitch.max < 7.8\nand\n$analysis.rollout.pitch.max < 7.8",
+                    "primaryCondition": "$analysis.touchdown_combined.pitch.max < 7.8 and $analysis.rollout.pitch.max < 7.8",
                     "beginConditionMarker": "#CH",
                     "endConditionMarker": "#INSTANT",
-                    "description": "Pitch attitude during touchdown and rollout\nshould be below 7.8 degree.\nDanger of tailstrike!\nMake sure your speed at touchdown is not (much) below VLS"
+                    "description": "Pitch attitude during touchdown and rollout should be below 7.8 degree. Danger of tailstrike! Make sure your speed at touchdown is not (much) below VLS"
                 }
             ]
         },
@@ -329,7 +329,7 @@
                     "beginConditionMarker": "$.ft_ARTE < 50",
                     "endConditionMarker": "#TD_LAST",
                     "tolerance": 1000,
-                    "description": "Tailwind on runway was above 10kn.\nMake the opposite runway would be more suitable."
+                    "description": "Tailwind on runway was above 10kn. Make the opposite runway would be more suitable."
                 }
             ]
         }


### PR DESCRIPTION
Possible fix for control device problems. 
Instead of defining special curves for controllers at (user) X-Plane level we can just use `greater than` check for flap deploy ratio.
This change should cover both direct keyboard / mouse / button commands and axis tied flap lever (like TCA, Honeycomb etc) configurations.

If this logic works, all other profiles needs to be changed `$sim/cockpit2/controls/flap_handle_deploy_ratio >= 0.745` 
0.745 was used to allow some safety margin to controllers, it can be increased to maybe 0.748 or 0.749 and be closer to 0.75 if needed.

Also cleaned out the code a little bit for better readability (removed \n's from the conditions and descriptions)