### PR TITLE
Update MD-11 acf.author to match current MD-11 v1.09 author string

### DIFF
--- a/aircraftConfigs/MD11_by_(c) 2.sacfg
+++ b/aircraftConfigs/MD11_by_(c) 2.sacfg
@@ -2,7 +2,7 @@
     "enabled": true,
     "acf": {
         "icao": "MD11",
-        "author": "(c) 2013-2023 Juan Alcon, Ivan Arroyo, Alfredo Torrado"
+        "author": "(c) 2013-2024 Juan Alcon, Ivan Arroyo, Alfredo Torrado"
     },
     "speed": {
         "taxi": -1


### PR DESCRIPTION
Just a simple fix to match the current Rotate MD-11 v1.09 `author` string.