### PR TITLE
ToLiss A21N Support

### DIFF
--- a/aircraftConfigs/A21N_by_Glidi.sacfg
+++ b/aircraftConfigs/A21N_by_Glidi.sacfg
@@ -1,0 +1,117 @@
+{
+    "enabled": true,
+    "acf": {
+        "icao": "A21N",
+        "author": "Gliding Kiwi"
+    },
+    "speed": {
+        "taxi": -1
+    },
+    "autoUpdate": true,
+    "replace_dref": [
+        {
+            "old": "sim/cockpit/radios/nav1_freq_hz",
+            "new": "toliss_airbus/pfdoutputs/general/ils_frequency"
+        },
+        {
+            "old": "sim/cockpit/radios/nav1_hdef_dot",
+            "new": "AirbusFBW/ILS1LocRaw"
+        },
+        {
+            "old": "sim/cockpit/radios/nav1_vdef_dot",
+            "new": "AirbusFBW/ILS1GSRaw"
+        }
+    ],
+    "checkHeights": [
+        {
+            "template": "IMC"
+        },
+        {
+            "template": "VMC"
+        },
+        {
+            "template": "VISUAL"
+        }
+    ],
+    "requirementGroups": [
+        {
+            "template": "Stopping distance"
+        },
+        {
+            "template": "Touchdown zone"
+        },
+        {
+            "template": "Centerline deviation"
+        },
+        {
+            "template": "Single touchdown"
+        },
+        {
+            "template": "Touchdown rate (fpm)"
+        },
+        {
+            "template": "Touchdown g-force"
+        },
+        {
+            "template": "Sink rate"
+        },
+        {
+            "template": "Bank angle"
+        },
+        {
+            "template": "Glideslope deviation",
+            "replace": {
+                "$VDOT": "$AirbusFBW/ILS1GSRaw"
+            }
+        },
+        {
+            "template": "Localizer deviation",
+            "replace": {
+                "$HDOT": "$AirbusFBW/ILS1LocRaw"
+            }
+        },
+        {
+            "template": "Approach speed (Vref)",
+            "replace": {
+                "$VREF": "$toliss_airbus/pfdoutputs/general/VLS_value",
+                "$KIAS": "$sim/cockpit2/gauges/indicators/airspeed_kts_pilot"
+            }
+        },
+        {
+            "template": "Flaps",
+            "replace": {
+                "$FLAPSCONDITION": "($AirbusFBW/FlapLeverRatio >= 0.70 and $AirbusFBW/FlapLeverRatio <= 0.80) or $AirbusFBW/FlapLeverRatio >= 0.95",
+                "$FLAPSTEXT": "3 or FULL"
+            }
+        },
+        {
+            "template": "Gear",
+            "replace": {
+                "$CONDITION": "$AirbusFBW/RightGearInd == 2 and $AirbusFBW/LeftGearInd == 2 and $AirbusFBW/NoseGearInd == 2"
+            }
+        },
+        {
+            "template": "Speedbrake",
+            "replace": {
+                "$CONDITION": "$sim/cockpit2/controls/speedbrake_ratio < -0.2"
+            }
+        },
+        {
+            "template": "Autoflight",
+            "replace": {
+                "$CONDITION": "$AirbusFBW/AP1Engage == 0 and $AirbusFBW/AP2Engage == 0"
+            }
+        },
+        {
+            "template": "No Tailstrike",
+            "replace": {
+                "$TAILSTRIKEPITCH": "10.8",
+                "$CAUTIONPITCH": "7.8"
+            }
+        },
+        {
+            "template": "Wind limits"
+        }
+
+    ]
+}


### PR DESCRIPTION
This will add support for ToLiSs A321 NEO (A21N).

Even though default Toliss always reports A321 as icao code, there was a discussions about this and a xlua script was offered as a solution to change/correct icao code upon aircraft load (from A321 to A21N) or engine type change via their config tool.

And when this happens, StableApproach fails to identify the aircraft. Having this file in the repository will solve the issue.